### PR TITLE
Activate H2 only when it's supported by the bundled OpenSSL version

### DIFF
--- a/lib/Vhost.php
+++ b/lib/Vhost.php
@@ -29,7 +29,6 @@ class Vhost {
         "reneg_limit"           => 0,
         "reneg_limit_callback"  => null,
         "crypto_method"         => STREAM_CRYPTO_METHOD_TLS_SERVER,
-        //"alpn_protocols"        => "h2", // @TODO
     ];
 
     private static $cryptoMethodMap = [
@@ -56,6 +55,10 @@ class Vhost {
         $this->application = $application;
         $this->filters = $filters;
         $this->id = ($this->name ?? $this->address) . ":" . $this->port;
+
+        if ($this->hasAlpnSupport()) {
+            $this->tlsDefaults["alpn_protocols"] = "h2";
+        }
     }
 
     private function setAddress(string $address) {
@@ -302,6 +305,18 @@ class Vhost {
         $tls['crypto_method'] = $bitmask;
 
         return $tls;
+    }
+
+    /**
+     * @see https://wiki.openssl.org/index.php/Manual:OPENSSL_VERSION_NUMBER(3)
+     * @return bool
+     */
+    private function hasAlpnSupport() {
+        if (!defined("OPENSSL_VERSION_NUMBER")) {
+            return false;
+        }
+
+        return \OPENSSL_VERSION_NUMBER >= 0x10002000;
     }
 
     /**


### PR DESCRIPTION
Don't merge as long as H2 doesn't run without problems.