### PR TITLE
Deprecate AERYS_OPTIONS

### DIFF
--- a/test/BootstrapperTest.php
+++ b/test/BootstrapperTest.php
@@ -82,4 +82,8 @@ class BootstrapperTest extends \PHPUnit_Framework_TestCase {
         $vhosts["foo.bar:80"]->getApplication()(new StandardRequest($ireq = new InternalRequest), new StandardResponse((function(){yield;})(), new Client))->next();
         $this->assertEquals(["responder" => 1, "foo.bar" => 1], $ireq->locals);
     }
+
+    public function tearDown() {
+        (function() { Host::$definitions = []; })->bindTo(null, Host::class)();
+    }
 }

--- a/test/TestBootstrapperInclude.php
+++ b/test/TestBootstrapperInclude.php
@@ -1,8 +1,7 @@
 <?php
 
-const AERYS_OPTIONS = [
-    "shutdownTimeout" => 5000
-];
+/** @var Aerys\Options $options */
+$options->shutdownTimeout = 5000;
 
 class OurMiddleware implements \Aerys\Middleware {
     public function do(\Aerys\InternalRequest $ireq) {


### PR DESCRIPTION
What do you think about not using a constant?

It has the advantage of not having to define() the array (gives you more freedom when assembling options) … but maybe it is a fine as is as it forces the options to be centralized more or less in one single place.

So, please think about it … I'm unsure too.