### PR TITLE
Fixes filename normalizer on Windows

### DIFF
--- a/lib/CommandClient.php
+++ b/lib/CommandClient.php
@@ -17,7 +17,7 @@ class CommandClient {
     }
 
     public static function socketPath(string $config) {
-        return sys_get_temp_dir()."/aerys_".str_replace(["/", ":"], "_", Bootstrapper::selectConfigFile($config)).".tmp";
+        return sys_get_temp_dir()."/aerys_".str_replace(["\\", "/", ":"], "_", Bootstrapper::selectConfigFile($config)).".tmp";
     }
 
     private function send($msg): \Amp\Promise {


### PR DESCRIPTION
CommandClient::socketPath normalizes paths by replacing `/` and `:` with underscores. But Windows uses backslashes `\`.

This PR fixes it by als adding backslash to the search list.