### PR TITLE
Handle MIME types with suffixes correctly

### DIFF
--- a/lib/Root.php
+++ b/lib/Root.php
@@ -665,7 +665,7 @@ class Root implements ServerObserver {
                 "Failed loading mime associations from file {$mimeFile}"
             );
         }
-        if (!preg_match_all("#\s*([a-z0-9]+)\s+([a-z0-9\-]+/[a-z0-9\-]+)#i", $mimeStr, $matches)) {
+        if (!preg_match_all("#\s*([a-z0-9]+)\s+([a-z0-9\-]+/[a-z0-9\-]+(?:\+[a-z0-9\-]+)?)#i", $mimeStr, $matches)) {
             throw new \RuntimeException(
                 "No mime associations found in file: {$mimeFile}"
             );


### PR DESCRIPTION
`Aerys\Root` sets the MIME type for HTTP responses by looking up the file extension of the requested file in the [mime file](https://github.com/amphp/aerys/blob/v0.4.3/etc/mime). However, when `Aerys\Root` parses the mime file, the regex used ignores MIME type suffixes. This means that for `.svg` files, Aerys response with a content type of `image/svg` instead of `image/svg+xml`, which prevents browsers from displaying `svg` files correctly. This PR addresses this issue.