### PR TITLE
Split send method

### DIFF
--- a/demo.php
+++ b/demo.php
@@ -76,7 +76,7 @@ $websocket = websocket(new class implements Aerys\Websocket {
 
     public function onData(int $clientId, Websocket\Message $msg) {
         // broadcast to all connected clients
-        $this->endpoint->send(null, yield $msg);
+        $this->endpoint->broadcast(yield $msg);
     }
 
     public function onClose(int $clientId, int $code, string $reason) { }

--- a/lib/Websocket/Endpoint.php
+++ b/lib/Websocket/Endpoint.php
@@ -33,7 +33,7 @@ interface Endpoint {
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function simulcast(string $data, array $clientIds): Promise;
+    public function multicast(string $data, array $clientIds): Promise;
 
     /**
      * Send a binary message to the given client(s).
@@ -63,7 +63,7 @@ interface Endpoint {
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function simulcastBinary(string $data, array $clientIds): Promise;
+    public function multicastBinary(string $data, array $clientIds): Promise;
 
     /**
      * Close the client connection with a code and UTF-8 string reason.

--- a/lib/Websocket/Endpoint.php
+++ b/lib/Websocket/Endpoint.php
@@ -6,24 +6,44 @@ use AsyncInterop\Promise;
 
 interface Endpoint {
     /**
-     * Send a UTF-8 text message to the given client(s).
+     * Send a UTF-8 text message to the given client.
      *
-     * @param int|array|null $clientId Single client ID to send data to, an array of client IDs, or null for all clients.
      * @param string $data Data to send.
+     * @param int $clientId
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function send(/* int|null|array */ $clientId, string $data): Promise;
+    public function send(string $data, int $clientId): Promise;
+
+    /**
+     * Broadcast a UTF-8 text message to a set of clients.
+     *
+     * @param string $data Data to send.
+     * @param int[]|null $clientIds Array of client IDs or null for all clients.
+     *
+     * @return \AsyncInterop\Promise<int>
+     */
+    public function broadcast(string $data, array $clientIds = null): Promise;
 
     /**
      * Send a binary message to the given client(s).
      *
-     * @param int|array|null $clientId Single client ID to send data to, an array of client IDs, or null for all clients.
      * @param string $data Data to send.
+     * @param int $clientId
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function sendBinary(/* int|null|array */ $clientId, string $data): Promise;
+    public function sendBinary(string $data, int $clientId): Promise;
+
+    /**
+     * Send a binary message to a set of clients.
+     *
+     * @param string $data Data to send.
+     * @param int[]|null $clientIds Array of client IDs or null for all clients.
+     *
+     * @return \AsyncInterop\Promise<int>
+     */
+    public function broadcastBinary(string $data, array $clientIds = null): Promise;
 
     /**
      * Close the client connection with a code and UTF-8 string reason.

--- a/lib/Websocket/Endpoint.php
+++ b/lib/Websocket/Endpoint.php
@@ -19,11 +19,11 @@ interface Endpoint {
      * Broadcast a UTF-8 text message to all clients (except those given in the optional array).
      *
      * @param string $data Data to send.
-     * @param int[]|null $exceptIds List of IDs to exclude from the broadcast.
+     * @param int[] $exceptIds List of IDs to exclude from the broadcast.
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function broadcast(string $data, array $exceptIds = null): Promise;
+    public function broadcast(string $data, array $exceptIds = []): Promise;
 
     /**
      * Send a UTF-8 text message to a set of clients.
@@ -49,11 +49,11 @@ interface Endpoint {
      * Send a binary message to all clients (except those given in the optional array).
      *
      * @param string $data Data to send.
-     * @param int[]|null $exceptIds List of IDs to exclude from the broadcast.
+     * @param int[] $exceptIds List of IDs to exclude from the broadcast.
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function broadcastBinary(string $data, array $clientIds = null): Promise;
+    public function broadcastBinary(string $data, array $exceptIds = []): Promise;
 
     /**
      * Send a binary message to a set of clients.

--- a/lib/Websocket/Endpoint.php
+++ b/lib/Websocket/Endpoint.php
@@ -16,14 +16,24 @@ interface Endpoint {
     public function send(string $data, int $clientId): Promise;
 
     /**
-     * Broadcast a UTF-8 text message to a set of clients.
+     * Broadcast a UTF-8 text message to all clients (except those given in the optional array).
      *
      * @param string $data Data to send.
-     * @param int[]|null $clientIds Array of client IDs or null for all clients.
+     * @param int[]|null $exceptIds List of IDs to exclude from the broadcast.
      *
      * @return \AsyncInterop\Promise<int>
      */
-    public function broadcast(string $data, array $clientIds = null): Promise;
+    public function broadcast(string $data, array $exceptIds = null): Promise;
+
+    /**
+     * Send a UTF-8 text message to a set of clients.
+     *
+     * @param string $data Data to send.
+     * @param int[]|null $clientIds Array of client IDs.
+     *
+     * @return \AsyncInterop\Promise<int>
+     */
+    public function simulcast(string $data, array $clientIds): Promise;
 
     /**
      * Send a binary message to the given client(s).
@@ -36,14 +46,24 @@ interface Endpoint {
     public function sendBinary(string $data, int $clientId): Promise;
 
     /**
-     * Send a binary message to a set of clients.
+     * Send a binary message to all clients (except those given in the optional array).
      *
      * @param string $data Data to send.
-     * @param int[]|null $clientIds Array of client IDs or null for all clients.
+     * @param int[]|null $exceptIds List of IDs to exclude from the broadcast.
      *
      * @return \AsyncInterop\Promise<int>
      */
     public function broadcastBinary(string $data, array $clientIds = null): Promise;
+
+    /**
+     * Send a binary message to a set of clients.
+     *
+     * @param string $data Data to send.
+     * @param int[]|null $clientIds Array of client IDs.
+     *
+     * @return \AsyncInterop\Promise<int>
+     */
+    public function simulcastBinary(string $data, array $clientIds): Promise;
 
     /**
      * Close the client connection with a code and UTF-8 string reason.

--- a/lib/Websocket/Rfc6455Endpoint.php
+++ b/lib/Websocket/Rfc6455Endpoint.php
@@ -12,27 +12,27 @@ class Rfc6455Endpoint implements Endpoint {
     }
 
     public function send(string $data, int $clientId): Promise {
-        return $this->gateway->send($clientId, $data, false);
+        return $this->gateway->send($data, false, $clientId);
     }
 
     public function sendBinary(string $data, int $clientId): Promise {
-        return $this->gateway->send($clientId, $data, true);
+        return $this->gateway->send($data, true, $clientId);
     }
 
-    public function broadcast(string $data, array $exceptIds = null): Promise {
-        return $this->gateway->broadcast($exceptIds, $data, false);
+    public function broadcast(string $data, array $exceptIds = []): Promise {
+        return $this->gateway->broadcast($data, false, $exceptIds);
     }
 
-    public function broadcastBinary(string $data, array $exceptIds = null): Promise {
-        return $this->gateway->broadcast($exceptIds, $data, true);
+    public function broadcastBinary(string $data, array $exceptIds = []): Promise {
+        return $this->gateway->broadcast($data, true, $exceptIds);
     }
 
     public function multicast(string $data, array $clientIds): Promise {
-        return $this->gateway->multicast($clientIds, $data, false);
+        return $this->gateway->multicast($data, false, $clientIds);
     }
 
     public function multicastBinary(string $data, array $clientIds): Promise {
-        return $this->gateway->multicast($clientIds, $data, true);
+        return $this->gateway->multicast($data, true, $clientIds);
     }
 
     public function close(int $clientId, int $code = Code::NORMAL_CLOSE, string $reason = ""): Promise {

--- a/lib/Websocket/Rfc6455Endpoint.php
+++ b/lib/Websocket/Rfc6455Endpoint.php
@@ -11,12 +11,20 @@ class Rfc6455Endpoint implements Endpoint {
         $this->gateway = $gateway;
     }
 
-    public function send($clientId, string $data): Promise {
+    public function send(string $data, int $clientId): Promise {
         return $this->gateway->send($clientId, $data, false);
     }
 
-    public function sendBinary($clientId, string $data): Promise {
+    public function sendBinary(string $data, int $clientId): Promise {
         return $this->gateway->send($clientId, $data, true);
+    }
+
+    public function broadcast(string $data, array $clientIds = null): Promise {
+        return $this->gateway->broadcast($clientIds, $data, false);
+    }
+
+    public function broadcastBinary(string $data, array $clientIds = null): Promise {
+        return $this->gateway->broadcast($clientIds, $data, true);
     }
 
     public function close(int $clientId, int $code = Code::NORMAL_CLOSE, string $reason = ""): Promise {

--- a/lib/Websocket/Rfc6455Endpoint.php
+++ b/lib/Websocket/Rfc6455Endpoint.php
@@ -19,12 +19,20 @@ class Rfc6455Endpoint implements Endpoint {
         return $this->gateway->send($clientId, $data, true);
     }
 
-    public function broadcast(string $data, array $clientIds = null): Promise {
-        return $this->gateway->broadcast($clientIds, $data, false);
+    public function broadcast(string $data, array $exceptIds = null): Promise {
+        return $this->gateway->broadcast($exceptIds, $data, false);
     }
 
-    public function broadcastBinary(string $data, array $clientIds = null): Promise {
-        return $this->gateway->broadcast($clientIds, $data, true);
+    public function broadcastBinary(string $data, array $exceptIds = null): Promise {
+        return $this->gateway->broadcast($exceptIds, $data, true);
+    }
+
+    public function simulcast(string $data, array $clientIds = null): Promise {
+        return $this->gateway->simulcast($clientIds, $data, false);
+    }
+
+    public function simulcastBinary(string $data, array $clientIds = null): Promise {
+        return $this->gateway->simulcast($clientIds, $data, true);
     }
 
     public function close(int $clientId, int $code = Code::NORMAL_CLOSE, string $reason = ""): Promise {

--- a/lib/Websocket/Rfc6455Endpoint.php
+++ b/lib/Websocket/Rfc6455Endpoint.php
@@ -27,11 +27,11 @@ class Rfc6455Endpoint implements Endpoint {
         return $this->gateway->broadcast($exceptIds, $data, true);
     }
 
-    public function multicast(string $data, array $clientIds = null): Promise {
+    public function multicast(string $data, array $clientIds): Promise {
         return $this->gateway->multicast($clientIds, $data, false);
     }
 
-    public function multicastBinary(string $data, array $clientIds = null): Promise {
+    public function multicastBinary(string $data, array $clientIds): Promise {
         return $this->gateway->multicast($clientIds, $data, true);
     }
 

--- a/lib/Websocket/Rfc6455Endpoint.php
+++ b/lib/Websocket/Rfc6455Endpoint.php
@@ -27,12 +27,12 @@ class Rfc6455Endpoint implements Endpoint {
         return $this->gateway->broadcast($exceptIds, $data, true);
     }
 
-    public function simulcast(string $data, array $clientIds = null): Promise {
-        return $this->gateway->simulcast($clientIds, $data, false);
+    public function multicast(string $data, array $clientIds = null): Promise {
+        return $this->gateway->multicast($clientIds, $data, false);
     }
 
-    public function simulcastBinary(string $data, array $clientIds = null): Promise {
-        return $this->gateway->simulcast($clientIds, $data, true);
+    public function multicastBinary(string $data, array $clientIds = null): Promise {
+        return $this->gateway->multicast($clientIds, $data, true);
     }
 
     public function close(int $clientId, int $code = Code::NORMAL_CLOSE, string $reason = ""): Promise {

--- a/lib/Websocket/Rfc6455Gateway.php
+++ b/lib/Websocket/Rfc6455Gateway.php
@@ -619,7 +619,7 @@ class Rfc6455Gateway implements Middleware, Monitor, ServerObserver {
         return all($promises);
     }
 
-    public function simulcast(array $clientIds, string $data, bool $binary): Promise {
+    public function multicast(array $clientIds, string $data, bool $binary): Promise {
         $promises = [];
         foreach ($clientIds as $id) {
             $promises[] = $this->send($id, $data, $binary);

--- a/test/WebsocketTest.php
+++ b/test/WebsocketTest.php
@@ -361,7 +361,7 @@ class WebsocketTest extends \PHPUnit_Framework_TestCase {
                 function onData(int $clientId, Websocket\Message $msg) {
                     $this->endpoint->broadcast("foo".str_repeat("*", 65528 /* fill buffer */));
                     $this->endpoint->send("bar", $clientId);
-                    yield $this->endpoint->broadcast("baz", [$clientId]);
+                    yield $this->endpoint->simulcast("baz", [$clientId]);
                     $this->endpoint->close($clientId);
                 }
             });

--- a/test/WebsocketTest.php
+++ b/test/WebsocketTest.php
@@ -361,7 +361,7 @@ class WebsocketTest extends \PHPUnit_Framework_TestCase {
                 function onData(int $clientId, Websocket\Message $msg) {
                     $this->endpoint->broadcast("foo".str_repeat("*", 65528 /* fill buffer */));
                     $this->endpoint->send("bar", $clientId);
-                    yield $this->endpoint->simulcast("baz", [$clientId]);
+                    yield $this->endpoint->multicast("baz", [$clientId]);
                     $this->endpoint->close($clientId);
                 }
             });


### PR DESCRIPTION
This PR splits `Endpoint::send()` into three methods:
 - `Endpoint::send(string $data, int $clientId)` for sending messages to a single client.
 - `Endpoint::broadcast(string $data, array $exceptIds = null)` for sending to all clients (optionally excluding those given in the array).
- `Endpoint::multicast(string $data, array $clientIds)` for sending to a set of specific clients.

`Endpoint::sendBinary()` is similarly split into three methods, adding `Endpoint::broadcastBinary()` and `Endpoint::multicastBinary()`.

Having three distinct methods for sending messages to a single client, all clients, or to a set of clients makes it easier to determine where messages are going at a glance.