### PR TITLE
Downgraded nikic php router to 0.8 for lumen FW compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "amphp/file": "^0.1.1",
         "amphp/socket": "^0.9",
         "league/climate": "^3",
-        "nikic/fast-route": "^1",
+        "nikic/fast-route": "~0.8",
         "psr/log": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
Downgraded nikic php routes to 0.8 for lumen FW compatibility