### PR TITLE
Add PHP 7.1 to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 
 php:
   - 7.0
+  - 7.1
   - nightly
 
 matrix:


### PR DESCRIPTION
I just hit an issue where Aerys was not running properly on 7.1.2 but downgrading to 7.1.1 resolved the issue. I've just seen that Travis is only building against 7.0, not 7.1, so this PR adds 7.1 to the Travis config.