### PR TITLE
Add possibility to specify php options for workers

### DIFF
--- a/lib/WatcherProcess.php
+++ b/lib/WatcherProcess.php
@@ -388,6 +388,10 @@ class WatcherProcess extends Process {
     private function generateWorkerCommand(Console $console): string {
         $parts[] = \PHP_BINARY;
 
+        if (false === php_ini_scanned_files()) {
+            $parts[] = "-n";
+        }
+
         if ($ini = \get_cfg_var("cfg_file_path")) {
             $parts[] = "-c";
             $parts[] = $ini;


### PR DESCRIPTION
There must be possibility to adjust workers PHP arguments as well.
I propose following approach:
```
./aerys/vendor/bin/aerys -c ./aerys/server.php --worker-args="-n"
```