### PR TITLE
Add option to skip host matching for single vhost servers

### DIFF
--- a/lib/Options.php
+++ b/lib/Options.php
@@ -23,6 +23,7 @@ class Options {
     private $maxConcurrentStreams = 20;
     private $maxFramesPerSecond = 60;
     private $allowedMethods = ["GET", "POST", "PUT", "PATCH", "HEAD", "OPTIONS", "DELETE"];
+    private $strictHostMatch = true;
     private $deflateEnable;
     private $deflateContentTypes = '#^(?:text/.*+|[^/]*+/xml|[^+]*\+xml|application/(?:json|(?:x-)?javascript))$#i';
     private $configPath = null;
@@ -369,5 +370,9 @@ class Options {
         }
 
         $this->configPath = $config;
+    }
+
+    private function setStrictHostMatch(bool $flag) {
+        $this->strictHostMatch = $flag;
     }
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -549,7 +549,7 @@ function initServer(PsrLogger $logger, array $hosts, array $options = []): Serve
     }
 
     $options = Internal\generateOptionsObjFromArray($options);
-    $vhosts = new VhostContainer(new Http1Driver);
+    $vhosts = new VhostContainer(new Http1Driver, $options);
     $ticker = new Ticker($logger);
     $server = new Server($options, $vhosts, $logger, $ticker);
 


### PR DESCRIPTION
Addresses #124.

If the server contains only a single VHost and the `strictHostMatch` option is set to `false`, the single VHost is always selected regardless of the Host header.