### PR TITLE
Fix #124 (the second)

### DIFF
--- a/lib/Host.php
+++ b/lib/Host.php
@@ -3,7 +3,7 @@
 namespace Aerys;
 
 class Host {
-    private $name = "";
+    private $name = "*";
     private $interfaces = null;
     private $crypto = [];
     private $actions = [];
@@ -16,8 +16,8 @@ class Host {
      * "all IPv4 interfaces" and is appropriate for most users. Use "::" to indicate "all IPv6
      * interfaces". To indicate "all IPv4 *and* IPv6 interfaces", use a "*" wildcard character.
      *
-     * Note that "::" may also listen on some systems on IPv4 interfaces. PHP currently does
-     * not expose the IPV6_V6ONLY constant.
+     * Note that "::" may also listen on some systems on IPv4 interfaces. PHP did not expose the
+     * IPV6_V6ONLY constant before PHP 7.0.1.
      *
      * Any valid port number [1-65535] may be used. Port numbers lower than 256 are reserved for
      * well-known services (like HTTP on port 80) and port numbers less than 1024 require root
@@ -57,14 +57,18 @@ class Host {
     /**
      * Assign a domain name (e.g. localhost or mysite.com or subdomain.mysite.com).
      *
-     * A host name is only required if a server exposes more than one host. If a name is not defined
-     * the server will default to "localhost"
+     * An explicit host name is only required if a server exposes more than one host on a given
+     * interface. If a name is not defined (or "*") the server will allow any hostname.
+     *
+     * By default the port must match with the interface. It is possible to explicitly require
+     * a specific port in the hostname by appending ":port" (e.g. "localhost:8080"). It is also
+     * possible to specify a wildcard with "*" (e.g. "*:*" to accept any hostname from any port).
      *
      * @param string $name
      * @return self
      */
     public function name(string $name): Host {
-        $this->name = $name;
+        $this->name = $name === "" ? "*" : $name;
 
         return $this;
     }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -121,8 +121,9 @@ class ClientTest extends TestCase {
 
             $context = (new ClientTlsContext)->withoutPeerVerification();
             $client = new DefaultClient(null, null, $context);
+            $port = parse_url($address, PHP_URL_PORT);
             $promise = $client->request(
-                (new \Amp\Artax\Request("https://$address/", "POST"))->withBody("body")
+                (new \Amp\Artax\Request("https://localhost:$port/", "POST"))->withBody("body")
             );
 
             $response = yield $promise;

--- a/test/bootServerTest.php
+++ b/test/bootServerTest.php
@@ -71,14 +71,14 @@ class BootstrapperTest extends TestCase {
         $this->assertEquals(5000, $server->getOption("shutdownTimeout")); // custom option test
 
         $vhosts = $info["vhosts"]->__debugInfo()["vhosts"];
-        $this->assertEquals(["localhost:443", "example.com:80", "foo.bar:80"], array_keys($vhosts));
-        $this->assertInternalType('callable', $vhosts["localhost:443"]->getApplication());
-        $middleware = current($vhosts["example.com:80"]->getFilters());
+        $this->assertEquals(["localhost:443:[::]:443", "localhost:443:0.0.0.0:443", "example.com:80:127.0.0.1:80", "foo.bar:80:127.0.0.1:80"], array_keys($vhosts));
+        $this->assertInternalType('callable', $vhosts["localhost:443:0.0.0.0:443"]->getApplication());
+        $middleware = current($vhosts["example.com:80:127.0.0.1:80"]->getFilters());
         $this->assertInstanceOf("OurMiddleware", $middleware[0]);
         $this->assertEquals("do", $middleware[1]);
-        $this->assertInstanceOf("OurMiddleware", $vhosts["example.com:80"]->getApplication());
-        $this->assertEquals(2, count($vhosts["foo.bar:80"]->getApplication()->__debugInfo()["applications"]));
-        $vhosts["foo.bar:80"]->getApplication()(new StandardRequest($ireq = new InternalRequest), new StandardResponse((function () {yield;})(), new Client))->next();
+        $this->assertInstanceOf("OurMiddleware", $vhosts["example.com:80:127.0.0.1:80"]->getApplication());
+        $this->assertEquals(2, count($vhosts["foo.bar:80:127.0.0.1:80"]->getApplication()->__debugInfo()["applications"]));
+        $vhosts["foo.bar:80:127.0.0.1:80"]->getApplication()(new StandardRequest($ireq = new InternalRequest), new StandardResponse((function () {yield;})(), new Client))->next();
         $this->assertEquals(["responder" => 1, "foo.bar" => 1], $ireq->locals);
     }
 
@@ -92,6 +92,6 @@ class BootstrapperTest extends TestCase {
 
         $server = \Aerys\initServer($logger, [(new Host)->name("foo.bar")]);
         $vhosts = $server->__debugInfo()["vhosts"]->__debugInfo()["vhosts"];
-        $this->assertEquals("foo.bar:80", key($vhosts));
+        $this->assertEquals("foo.bar:80:[::]:80", key($vhosts));
     }
 }


### PR DESCRIPTION
An alternate solution for #124 (previous PR at #170):

You can now set a specific expected port the client must specify in the Host header or wildcard port ("*") to avoid any port matching there.