### PR TITLE
Unix Domain Socket support (PR for #168)

### DIFF
--- a/bin/aerys-worker
+++ b/bin/aerys-worker
@@ -41,10 +41,6 @@ $climate->arguments->add([
         "prefix"       => "i",
         "required"     => true,
     ],
-    "socket-transfer" => [
-        "longPrefix"   => "socket-transfer",
-        "noValue"      => true,
-    ],
     "log" => [
         "prefix"       => "l",
         "required"     => true,

--- a/test/HostTest.php
+++ b/test/HostTest.php
@@ -14,7 +14,7 @@ class HostTest extends TestCase {
 
     /**
      * @expectedException \Error
-     * @expectedExceptionMessage Invalid port number; integer in the range 1..65535 required
+     * @expectedExceptionMessage Invalid port number 65536; integer in the range 1..65535 required
      */
     public function testThrowsWithBadPort() {
         $this->getHost()->expose("127.0.0.1", 65536);


### PR DESCRIPTION
As noted in #168: it is necessary to always use socket transfer for Unix Domain Sockets, thus we need to decide ourselves in worker whether to use socket transfer or not.

Thus, unix domain sockets should generally be impossible with < PHP 7.0.7 and without sockets extension in production mode (i.e. when using multiple workers).