### PR TITLE
Join Allow header values with comma and space (according with RFC 7231)

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -733,7 +733,7 @@ class Server implements Monitor {
         $body = makeGenericBody($status);
         $response->setStatus($status);
         $response->setHeader("Connection", "close");
-        $response->setHeader("Allow", implode(",", $this->options->allowedMethods));
+        $response->setHeader("Allow", implode(", ", $this->options->allowedMethods));
         $response->end($body);
     }
 
@@ -745,7 +745,7 @@ class Server implements Monitor {
 
     private function sendPreAppOptionsResponse(Request $request, Response $response) {
         $response->setStatus(HTTP_STATUS["OK"]);
-        $response->setHeader("Allow", implode(",", $this->options->allowedMethods));
+        $response->setHeader("Allow", implode(", ", $this->options->allowedMethods));
         $response->end();
     }
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -238,7 +238,7 @@ class ServerTest extends TestCase {
         list($headers) = $this->tryRequest([[HttpDriver::RESULT, $ireq]], function (Request $req, Response $res) { $this->fail("We should already have failed and never invoke the responder..."); });
 
         $this->assertEquals(\Aerys\HTTP_STATUS["OK"], $headers[":status"]);
-        $this->assertEquals(implode(",", (new Options)->allowedMethods), $headers["allow"][0]);
+        $this->assertEquals(implode(", ", (new Options)->allowedMethods), $headers["allow"][0]);
     }
 
     public function testError() {


### PR DESCRIPTION
In most web-servers and http-clients implementations header values joined with comma and space. 
I am fix it for `Allow` header in 2 places. 