### PR TITLE
Allow use of ServerTlsContext (or Certificate) within Host::encrypt

### DIFF
--- a/lib/Host.php
+++ b/lib/Host.php
@@ -2,6 +2,8 @@
 
 namespace Aerys;
 
+use Amp\Socket\{ Certificate, ServerTlsContext };
+
 class Host {
     private $name = "*";
     private $interfaces = null;
@@ -118,18 +120,17 @@ class Host {
     /**
      * Define TLS encryption settings for this host.
      *
-     * @param string $certificate A string path pointing to your SSL/TLS certificate
-     * @param string|null $key A string path pointing to your SSL/TLS key file (null if the certificate file is containing the key already)
-     * @param array $options An optional array mapping additional SSL/TLS settings
+     * @param string|Certificate|ServerTlsContext $certificate A string path pointing to your SSL/TLS certificate, a Certificate object, or a ServerTlsContext object
      * @return self
      */
-    public function encrypt(string $certificate, string $key = null, array $options = []): Host {
-        unset($options["SNI_server_certs"]);
-        $options["local_cert"] = $certificate;
-        if (isset($key)) {
-            $options["local_pk"] = $key;
+    public function encrypt($certificate): Host {
+        if (!$certificate instanceof ServerTlsContext) {
+            if (!$certificate instanceof Certificate) {
+                $certificate = new Certificate($certificate);
+            }
+            $certificate = (new ServerTlsContext)->withDefaultCertificate($certificate);
         }
-        $this->crypto = $options;
+        $this->crypto = $certificate;
 
         return $this;
     }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -16,7 +16,9 @@ use Aerys\Vhost;
 use Aerys\VhostContainer;
 use Amp\Artax\DefaultClient;
 use Amp\Loop;
+use Amp\Socket\Certificate;
 use Amp\Socket\ClientTlsContext;
+use Amp\Socket\ServerTlsContext;
 use PHPUnit\Framework\TestCase;
 
 class ClientTest extends TestCase {
@@ -30,7 +32,7 @@ class ClientTest extends TestCase {
 
         $vhosts = new VhostContainer(new Http2Driver);
         $vhost = new Vhost("localhost", [["127.0.0.1", $port]], $handler, $filters, [], new Http1Driver);
-        $vhost->setCrypto(["local_cert" => __DIR__."/server.pem", "crypto_method" => "tls"]);
+        $vhost->setCrypto((new ServerTlsContext)->withDefaultCertificate(new Certificate(__DIR__."/server.pem")));
         $vhosts->use($vhost);
 
         $logger = new class extends Logger {

--- a/test/VhostTest.php
+++ b/test/VhostTest.php
@@ -6,6 +6,8 @@ use Aerys\Client;
 use Aerys\InternalRequest;
 use Aerys\Vhost;
 use Aerys\VhostContainer;
+use Amp\Socket\Certificate;
+use Amp\Socket\ServerTlsContext;
 use PHPUnit\Framework\TestCase;
 
 class VhostTest extends TestCase {
@@ -94,7 +96,7 @@ class VhostTest extends TestCase {
         $vhost = new Vhost("*", [["127.0.0.1", 80], ["::", 80]], function () {}, [function () {yield;}]);
         $vhosts->use($vhost);
         $vhost = new Vhost("localhost", [["127.0.0.1", 80]], function () {}, [function () {yield;}]);
-        $vhost->setCrypto(["local_cert" => __DIR__."/server.pem"]);
+        $vhost->setCrypto((new ServerTlsContext)->withDefaultCertificate(new Certificate(__DIR__."/server.pem")));
         $vhosts->use($vhost);
     }
 
@@ -105,7 +107,7 @@ class VhostTest extends TestCase {
         $vhost = new Vhost("localhost", [["127.0.0.1", 80]], function () {}, []);
         $vhosts->use($vhost);
         $vhost = new Vhost("localhost", [["127.0.0.1", 8080]], function () {}, []);
-        $vhost->setCrypto(["local_cert" => __DIR__."/server.pem"]);
+        $vhost->setCrypto((new ServerTlsContext)->withDefaultCertificate(new Certificate(__DIR__."/server.pem")));
         $vhosts->use($vhost);
 
         $this->assertTrue(isset($vhosts->getTlsBindingsByAddress()["tcp://127.0.0.1:8080"]));


### PR DESCRIPTION
Implements the requested change in #200.