### PR TITLE
Fix logger hanging at 100% CPU on broken pipe

### DIFF
--- a/lib/IpcLogger.php
+++ b/lib/IpcLogger.php
@@ -50,7 +50,9 @@ class IpcLogger extends Logger {
             $this->writeQueue = [];
         }
 
-        $bytes = @fwrite($this->ipcSock, $this->writeBuffer);
+        $eh = set_error_handler([$this, 'onDeadIpcSock']);
+        $bytes = fwrite($this->ipcSock, $this->writeBuffer);
+        set_error_handler($eh);
         if ($bytes === false) {
             $this->onDeadIpcSock();
             return;


### PR DESCRIPTION
If an error handler is set and it returns 'true' on suppressed errors, there will be no error_get_last(), that's why a temp error handler is set here