### PR TITLE
Fix race condition during server shutdown + server restart

### DIFF
--- a/lib/CommandClient.php
+++ b/lib/CommandClient.php
@@ -98,6 +98,10 @@ class CommandClient {
         return $this->send(["action" => "stop"]);
     }
 
+    public function started(): Promise {
+        return $this->send(["action" => "started"]);
+    }
+
     public function importServerSockets($addrCtxMap): Promise {
         return call(function () use ($addrCtxMap) {
             $reply = yield $this->send(["action" => "import-sockets", "addrCtxMap" => array_map(function ($context) { return $context["socket"]; }, $addrCtxMap)]);

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -417,6 +417,12 @@ class Server implements Monitor {
         assert($this->logDebug("stopping"));
         $this->state = self::STOPPING;
 
+        // Unbind server sockets, otherwise connections are still sent to bound sockets but never accepted
+        // In restart situation that can lead to unnecessary request errors
+        foreach ($this->boundServers as $server) {
+            fclose($server);
+        }
+
         foreach ($this->acceptWatcherIds as $watcherId) {
             Loop::cancel($watcherId);
         }

--- a/lib/WorkerProcess.php
+++ b/lib/WorkerProcess.php
@@ -62,9 +62,11 @@ class WorkerProcess extends Process {
         }
         $this->server = $server;
         Loop::unreference(Loop::onReadable($this->ipcSock, function ($watcherId) {
+            $this->logger->info("Received stop command");
             Loop::cancel($watcherId);
             yield from $this->stop();
         }));
+        yield (new CommandClient($console->getArg("config")))->started();
     }
 
     protected function doStop(): \Generator {


### PR DESCRIPTION
1. During server stop, bound sockets are not closed. So they still receive new connections but never accept them. Leads to failed requests with SO_REUSEPORT
2. During server restart, old workers are stopped before new servers are ready. This may lead to 0 ready workers

I was able to reproduce this and prove it in production. The following graph shows 502 errors of Nginx acting as reverse proxy for Aerys: https://cl.ly/2P443d0o1F06
Vertical dotted lines are deploys, causing aerys restarts